### PR TITLE
Add configuration documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 ## Project Workflow Toolkit
 
 This repository contains tools and scripts to manage project workflows efficiently.
+
+## Configuration Options
+
+- `debug_mode`: Enables detailed debugging output for troubleshooting.
+- `log_level`: Sets the verbosity of logging (e.g., INFO, DEBUG, WARN, ERROR).
+- `max_connections`: Limits the maximum number of concurrent connections allowed.


### PR DESCRIPTION
This PR adds a new "Configuration Options" section to the README documenting `debug_mode`, `log_level`, and `max_connections` as per issue #7.